### PR TITLE
Bumping the default version to 1.32

### DIFF
--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -32,7 +32,7 @@ variable "open_match" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.28"
+  default = "1.32"
 }
 
 # Variable for ensuring that all available Managed Node Groups (MNGs) use arm-based instances


### PR DESCRIPTION
*Description of changes:* We keep this guidance aligned with the latest EKS version in order to maintain compatibility with Kubernetes. This change is intended to update the default version of EKS to the latest standard version. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
