### PR TITLE
Fix Terraform backend and EKS auth for manual deployments

### DIFF
--- a/terraform/cloudformation/buildspec.yml
+++ b/terraform/cloudformation/buildspec.yml
@@ -51,6 +51,7 @@ phases:
   build:
     commands:
       - echo "Initializing Terraform for cluster creation..."
+      - echo 'terraform { backend "s3" {} }' > terraform/cluster/backend-ci.tf
       - |
         terraform -chdir=terraform/cluster init \
           -backend-config="bucket=${TERRAFORM_STATE_BUCKET}" \
@@ -74,6 +75,7 @@ phases:
 
       - echo "Step 2 - Terraform Intra-Cluster"
       - echo "Initializing Terraform for intra-cluster configuration..."
+      - echo 'terraform { backend "s3" {} }' > terraform/intra-cluster/backend-ci.tf
       - |
         terraform -chdir=terraform/intra-cluster init \
           -backend-config="bucket=${TERRAFORM_STATE_BUCKET}" \
@@ -134,6 +136,7 @@ phases:
         export FLB_ARN=$(aws elbv2 describe-load-balancers --region ${REGION1} | jq -r ".LoadBalancers[] | select(.DNSName==\"$FLB_NAME\") | .LoadBalancerArn")
       - echo "FLB_ARN=$FLB_ARN"
       - echo "Initializing Terraform for extra-cluster configuration"
+      - echo 'terraform { backend "s3" {} }' > terraform/extra-cluster/backend-ci.tf
       - |
         terraform -chdir=terraform/extra-cluster init \
           -backend-config="bucket=${TERRAFORM_STATE_BUCKET}" \

--- a/terraform/cluster/backend.tf
+++ b/terraform/cluster/backend.tf
@@ -1,7 +1,4 @@
 terraform {
-  backend "s3" {
-    # This block is intentionally empty.
-    # Backend configuration will be provided via -backend-config parameters
-    # when initializing Terraform in the automated pipeline.
-  }
+  # Backend configuration is injected by the CI/CD pipeline (see buildspec.yml).
+  # Manual deployments use the default local backend.
 }

--- a/terraform/cluster/modules/cluster/main.tf
+++ b/terraform/cluster/modules/cluster/main.tf
@@ -196,6 +196,7 @@ module "eks" {
   }
 
  authentication_mode = "API_AND_CONFIG_MAP"
+  enable_cluster_creator_admin_permissions = true
   access_entries = {
     # Only create blueprint_admin entry
     blueprint_admin = {
@@ -274,7 +275,7 @@ provider "kubernetes" {
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
-    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name, "--region", var.cluster_region]
   }
 }
 data "aws_caller_identity" "current" {}

--- a/terraform/extra-cluster/backend.tf
+++ b/terraform/extra-cluster/backend.tf
@@ -1,7 +1,4 @@
 terraform {
-  backend "s3" {
-    # This block is intentionally empty.
-    # Backend configuration will be provided via -backend-config parameters
-    # when initializing Terraform in the automated pipeline.
-  }
+  # Backend configuration is injected by the CI/CD pipeline (see buildspec.yml).
+  # Manual deployments use the default local backend.
 }

--- a/terraform/intra-cluster/backend.tf
+++ b/terraform/intra-cluster/backend.tf
@@ -1,7 +1,4 @@
 terraform {
-  backend "s3" {
-    # This block is intentionally empty.
-    # Backend configuration will be provided via -backend-config parameters
-    # when initializing Terraform in the automated pipeline.
-  }
+  # Backend configuration is injected by the CI/CD pipeline (see buildspec.yml).
+  # Manual deployments use the default local backend.
 }

--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -23,7 +23,7 @@ provider "helm" {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--cluster-name", var.cluster_name]
+      args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region]
     }
   }
 }
@@ -37,7 +37,7 @@ provider "kubernetes" {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
     # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", var.cluster_name]
+    args = ["eks", "get-token", "--cluster-name", var.cluster_name, "--region", var.cluster_region]
   }
 }
 


### PR DESCRIPTION
Fixes #51

## Summary

- **Backend config:** Replace empty `backend "s3" {}` blocks with clean `terraform {}` blocks so manual deployments use local state by default. CI pipeline (`buildspec.yml`) now generates `backend-ci.tf` at build time to inject the S3 backend declaration — backend config is a deployment concern, not a code concern.
- **EKS auth:** Add `enable_cluster_creator_admin_permissions = true` to the EKS module so the deployer's IAM identity automatically gets cluster-admin access.
- **Region in auth tokens:** Add `--region` to all `aws eks get-token` exec blocks in Terraform providers to prevent silent auth failures when the deployer's default AWS region differs from the cluster region.

## Files Changed

| File | Change |
|------|--------|
| `terraform/cluster/backend.tf` | Remove S3 backend, default to local |
| `terraform/intra-cluster/backend.tf` | Same |
| `terraform/extra-cluster/backend.tf` | Same |
| `terraform/cloudformation/buildspec.yml` | Generate `backend-ci.tf` before each `terraform init` |
| `terraform/cluster/modules/cluster/main.tf` | Add `enable_cluster_creator_admin_permissions`, add `--region` to exec |
| `terraform/intra-cluster/main.tf` | Add `--region` to helm and kubernetes provider exec blocks |

## Test plan

- [x] `terraform init` succeeds in all three modules without S3 config
- [x] `terraform validate` passes in all three modules
- [ ] Full deploy to verify EKS cluster access and cross-region auth