### PR TITLE
Fix script paths and kubectl context matching

### DIFF
--- a/scripts/configure-agones-tls.sh
+++ b/scripts/configure-agones-tls.sh
@@ -4,7 +4,7 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 echo "- Verify that the Agones pods are running -"
 kubectl get pods -n agones-system -o wide
 export EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')

--- a/scripts/configure-multicluster-allocation.sh
+++ b/scripts/configure-multicluster-allocation.sh
@@ -4,9 +4,9 @@ set -o xtrace
 export CLUSTER1=$1
 export CLUSTER2=$2
 export ROOT_PATH=$3
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER2})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER2}$")
 export ALLOCATOR_IP_CLUSTER2=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER1})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$")
 export ALLOCATOR_IP_CLUSTER1=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 kubectl apply -f ${ROOT_PATH}/manifests/multicluster-allocation-1.yaml
 envsubst < ${ROOT_PATH}/manifests/multicluster-allocation-1-to-2.yaml | kubectl apply -f -

--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -4,7 +4,7 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 kubectl get pods -n open-match -o wide
 # Create Load Balancer
 kubectl expose deployment open-match-frontend  -n open-match  --type=LoadBalancer  --name="${CLUSTER_NAME}-om-fe"

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -8,7 +8,7 @@ export REGION2=$3
 export ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 export REGISTRY=${ACCOUNT_ID}.dkr.ecr.${REGION1}.amazonaws.com
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 echo "- Create configmap -"
 # Create the configmap that will store the certs/keys used by the Open Match Director to access the 
 # Agones Allocator Service (we use the files `client_*` and `ca_*` 

--- a/scripts/deploy-mapping-configmap.sh
+++ b/scripts/deploy-mapping-configmap.sh
@@ -11,7 +11,7 @@ ACCELERATOR_2_DNS=$(aws globalaccelerator describe-custom-routing-accelerator --
 
 aws globalaccelerator list-custom-routing-port-mappings --region us-west-2  --accelerator-arn $ACCELERATOR_1  --query 'PortMappings[].[AcceleratorPort,DestinationSocketAddress.IpAddress,DestinationSocketAddress.Port]' | jq -c '.[] | {key: "\(.[1]):\(.[2] | tostring)", value: .[0]}' | jq -s 'from_entries' | gzip > mapping1.gz
 aws globalaccelerator list-custom-routing-port-mappings --region us-west-2  --accelerator-arn $ACCELERATOR_2  --query 'PortMappings[].[AcceleratorPort,DestinationSocketAddress.IpAddress,DestinationSocketAddress.Port]' | jq -c '.[] | {key: "\(.[1]):\(.[2] | tostring)", value: .[0]}' | jq -s 'from_entries' | gzip > mapping2.gz
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME_1})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME_1}$")
 kubectl delete configmap global-accelerator-mapping --namespace agones-openmatch
 kubectl create configmap global-accelerator-mapping --namespace agones-openmatch --from-file=mapping1.gz --from-file=mapping2.gz --from-literal=accelerator1="$ACCELERATOR_1_DNS" --from-literal=accelerator2="$ACCELERATOR_2_DNS"
 rm mapping1.gz mapping2.gz

--- a/scripts/deploy-matchfunction.sh
+++ b/scripts/deploy-matchfunction.sh
@@ -13,7 +13,7 @@ docker buildx build  --platform=linux/amd64 -t $REGISTRY/agones-openmatch-mmf in
 echo "- Push image to register -"
 docker push $REGISTRY/agones-openmatch-mmf
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME1})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
 echo "- Deploy Open Match mmf to cluster ${CLUSTER_NAME1} -"
 envsubst < integration/matchfunction/matchfunction.yaml | kubectl apply --namespace ${NAMESPACE} -f -
 echo

--- a/scripts/deploy-ncat-fleets.sh
+++ b/scripts/deploy-ncat-fleets.sh
@@ -26,7 +26,7 @@ fi
 
 docker push $REGISTRY/agones-openmatch-ncat-server
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME1})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
 export REGION=$REGION1
 echo "- Deploy fleets to cluster ${CLUSTER_NAME1} -"
 for f in manifests/fleets/${GAMESERVER_TYPE}/*
@@ -39,7 +39,7 @@ kubectl get fleets --namespace ${NAMESPACE}
 kubectl get gameservers --namespace ${NAMESPACE} --show-labels
 echo
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME2})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$")
 export REGION=$REGION2
 echo "- Deploy fleets to cluster ${CLUSTER_NAME2} -"
 for f in manifests/fleets/${GAMESERVER_TYPE}/*

--- a/scripts/deploy-stk-fleets.sh
+++ b/scripts/deploy-stk-fleets.sh
@@ -36,7 +36,7 @@ docker push $REGISTRY/supertuxkart-server
 echo "supertuxkart build and push was successful"
 
 echo "- Deploy fleets to cluster ${CLUSTER_NAME1} -"
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME1})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
 export REGION=$REGION1
 for f in manifests/fleets/${GAMESERVER_TYPE}/*
 do
@@ -50,7 +50,7 @@ echo
 
 
 echo "- Deploy fleets to cluster ${CLUSTER_NAME2} -"
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME2})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$")
 export REGION=$REGION2
 for f in manifests/fleets/${GAMESERVER_TYPE}/*
 do

--- a/scripts/generate-agones-certs.sh
+++ b/scripts/generate-agones-certs.sh
@@ -4,7 +4,7 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 echo "- Verify that the cert-manager pods are running -"
 kubectl get pods -n cert-manager -o wide
 echo "- Verify the cert-manager webhook is available -"

--- a/scripts/generate-tls-files.sh
+++ b/scripts/generate-tls-files.sh
@@ -3,7 +3,7 @@
 set -o xtrace
 export CLUSTER_NAME=$1
 export ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 KEY_FILE=${ROOT_PATH}/client_${CLUSTER_NAME}.key
 CERT_FILE=${ROOT_PATH}/client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=${ROOT_PATH}/ca_${CLUSTER_NAME}.crt

--- a/scripts/set-allocator-ip.sh
+++ b/scripts/set-allocator-ip.sh
@@ -1,6 +1,6 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 CLUSTER_NAME=$1
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME}) 2>&1 > /dev/null
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$") 2>&1 > /dev/null
 ALLOCATOR_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 echo ${ALLOCATOR_IP}

--- a/scripts/test-agones-tls.sh
+++ b/scripts/test-agones-tls.sh
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 export CLUSTER_NAME=$1
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 KEY_FILE=client_${CLUSTER_NAME}.key
 CERT_FILE=client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=ca_${CLUSTER_NAME}.crt

--- a/scripts/test-gameserver-allocation.sh
+++ b/scripts/test-gameserver-allocation.sh
@@ -5,7 +5,7 @@ echo "#####"
 NAMESPACE=gameservers
 CLUSTER_NAME=$1
 REGION=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
 KEY_FILE=client_${CLUSTER_NAME}.key
 CERT_FILE=client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=ca_${CLUSTER_NAME}.crt

--- a/scripts/test-gameserver-multicluster-allocation.sh
+++ b/scripts/test-gameserver-multicluster-allocation.sh
@@ -11,7 +11,7 @@ REGION2=$4
 KEY_FILE=client_${CLUSTER_NAME1}.key
 CERT_FILE=client_${CLUSTER_NAME1}.crt
 TLS_CA_FILE=ca_${CLUSTER_NAME1}.crt
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME1})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
 EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 ENDPOINT=https://${EXTERNAL_IP}/gameserverallocation
 echo "- Allocating server -"
@@ -19,6 +19,6 @@ curl ${ENDPOINT} --key ${KEY_FILE} --cert ${CERT_FILE} --cacert ${TLS_CA_FILE} -
 echo
 echo "- Display ALLOCATED game servers on cluster ${CLUSTER_NAME1} only -"
 kubectl get gameservers --namespace ${GAMESERVER_NAMESPACE} | grep Allocated
-kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER_NAME2})
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$")
 echo "- Display ALLOCATED game servers on cluster ${CLUSTER_NAME2} only -"
 kubectl get gameservers --namespace ${GAMESERVER_NAMESPACE} | grep Allocated

--- a/terraform/cloudformation/buildspec.yml
+++ b/terraform/cloudformation/buildspec.yml
@@ -191,7 +191,7 @@ phases:
       - echo "Integrating Open Match with Agones..."
       - |
         cd $CODEBUILD_SRC_DIR
-        kubectl config use-context $(kubectl config get-contexts -o=name | grep ${CLUSTER1})
+        kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$")
         sh scripts/deploy-matchfunction.sh ${CLUSTER1} ${REGION1}
         sh scripts/deploy-director.sh ${CLUSTER1} ${REGION1} ${REGION2}
         kubectl get pods -n agones-openmatch

--- a/terraform/cloudformation/cleanup-buildspec.yml
+++ b/terraform/cloudformation/cleanup-buildspec.yml
@@ -245,8 +245,8 @@ phases:
       # Remove the clusters from kubectl config
       - |
         echo "Removing clusters from kubectl config..."
-        kubectl config delete-context $(kubectl config get-contexts -o=name | grep ${CLUSTER1}) 2>/dev/null || echo "No kubectl context found for cluster 1"
-        kubectl config delete-context $(kubectl config get-contexts -o=name | grep ${CLUSTER2}) 2>/dev/null || echo "No kubectl context found for cluster 2"
+        kubectl config delete-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$") 2>/dev/null || echo "No kubectl context found for cluster 1"
+        kubectl config delete-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER2}$") 2>/dev/null || echo "No kubectl context found for cluster 2"
 
   post_build:
     commands:

--- a/terraform/extra-cluster/main.tf
+++ b/terraform/extra-cluster/main.tf
@@ -15,6 +15,9 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 
+locals {
+  repo_root = "${path.module}/../.."
+}
 
 ## ECR
 resource "aws_ecr_replication_configuration" "cross_ecr_replication" {
@@ -253,7 +256,7 @@ resource "null_resource" "aga_mapping_cluster_1" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${path.cwd}/scripts/deploy-mapping-configmap.sh ${var.cluster_1_name} ${aws_globalaccelerator_custom_routing_accelerator.aga_gs_cluster_1.id} ${var.cluster_2_name} ${aws_globalaccelerator_custom_routing_accelerator.aga_gs_cluster_2.id}&"
+    command = "nohup ${local.repo_root}/scripts/deploy-mapping-configmap.sh ${var.cluster_1_name} ${aws_globalaccelerator_custom_routing_accelerator.aga_gs_cluster_1.id} ${var.cluster_2_name} ${aws_globalaccelerator_custom_routing_accelerator.aga_gs_cluster_2.id}&"
   }
 
   depends_on = [
@@ -272,7 +275,7 @@ resource "null_resource" "multicluster_allocation" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${path.cwd}/scripts/configure-multicluster-allocation.sh ${var.cluster_1_name} ${var.cluster_2_name} ${path.cwd}&"
+    command = "nohup ${local.repo_root}/scripts/configure-multicluster-allocation.sh ${var.cluster_1_name} ${var.cluster_2_name} ${local.repo_root}&"
   }
 
 }

--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -6,6 +6,7 @@ provider "aws" {
 }
 
 locals {
+  repo_root          = "${path.module}/../.."
   name               = var.cluster_name
   cluster_region     = var.cluster_region
   gameserver_minport = 7000
@@ -51,8 +52,8 @@ resource "kubernetes_namespace" "this" {
   provisioner "local-exec" {
 
     when    = destroy
-    command = "nohup ${path.cwd}/scripts/namespace-finalizer.sh ${each.key} 2>&1 &"
-    # command = "nohup ${path.cwd}/scripts/namespace-finalizer.sh ${var.cluster_name} ${each.key} 2>&1 &"
+    command = "nohup ${path.module}/../../scripts/namespace-finalizer.sh ${each.key} 2>&1 &"
+    # command = "nohup ${path.module}/../../scripts/namespace-finalizer.sh ${var.cluster_name} ${each.key} 2>&1 &"
   }
 }
 
@@ -257,7 +258,7 @@ resource "null_resource" "agones_tls_configuration" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${path.cwd}/scripts/configure-agones-tls.sh ${local.name} ${path.cwd}&"
+    command = "nohup ${local.repo_root}/scripts/configure-agones-tls.sh ${local.name} ${local.repo_root}&"
   }
 
   depends_on = [
@@ -275,7 +276,7 @@ resource "null_resource" "allocator_tls_files" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${path.cwd}/scripts/generate-tls-files.sh ${var.cluster_name} ${path.cwd} &"
+    command = "nohup ${local.repo_root}/scripts/generate-tls-files.sh ${var.cluster_name} ${local.repo_root} &"
   }
 
   depends_on = [
@@ -294,7 +295,7 @@ resource "null_resource" "open_match_ingress_configuration" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${path.cwd}/scripts/configure-open-match-ingress.sh ${var.cluster_name} ${path.cwd} &"
+    command = "nohup ${local.repo_root}/scripts/configure-open-match-ingress.sh ${var.cluster_name} ${local.repo_root} &"
   }
 
   depends_on = [
@@ -311,7 +312,7 @@ resource "null_resource" "generate_agones_certs" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${path.cwd}/scripts/generate-agones-certs.sh ${var.cluster_name} ${path.cwd} &"
+    command = "nohup ${local.repo_root}/scripts/generate-agones-certs.sh ${var.cluster_name} ${local.repo_root} &"
   }
 
   depends_on = [


### PR DESCRIPTION
Fixes #52

## Summary

- **Script paths:** Replace `path.cwd` with `local.repo_root` (`path.module/../..`) in all Terraform `null_resource` provisioners. When deploying manually per README (`cd terraform/intra-cluster && terraform apply`), `path.cwd` resolves to the terraform directory, not the repo root where `scripts/` and `manifests/` live. This caused every post-install script (TLS config, ClusterIssuer, Open Match ingress, port mapping) to fail silently under `nohup`. Also fixes the missing ClusterIssuer on Cluster 2 (the manifest was never applied because the path was wrong).
- **Context matching:** Anchor all kubectl context grep patterns from `grep ${CLUSTER_NAME}` to `grep "/${CLUSTER_NAME}$"` across 14 scripts and both buildspec files. Prevents failures when multiple EKS contexts share a name prefix.

## Files Changed

| Area | Files | Change |
|------|-------|--------|
| Terraform | `terraform/intra-cluster/main.tf` | Add `repo_root` local, replace 6x `path.cwd` |
| Terraform | `terraform/extra-cluster/main.tf` | Add `repo_root` local, replace 2x `path.cwd` |
| Scripts | 14 files in `scripts/` | Anchor grep with `"/${VAR}$"` |
| CI | `buildspec.yml`, `cleanup-buildspec.yml` | Same grep fix |

## Test plan

- [x] `terraform validate` passes for intra-cluster and extra-cluster
- [x] Zero `path.cwd` references remaining in terraform/
- [x] Zero unanchored `grep ${CLUSTER` patterns remaining in scripts/
- [ ] Full deploy to verify scripts find manifests and switch contexts correctly