### PR TITLE
Update Dockerfile Go builder image from 1.21 to 1.24

### DIFF
--- a/integration/director/Dockerfile
+++ b/integration/director/Dockerfile
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 
-FROM public.ecr.aws/docker/library/golang:1.21.4-alpine3.18 as go
+FROM public.ecr.aws/docker/library/golang:1.24-alpine as go
 RUN apk add git
 WORKDIR /app
 ENV GO111MODULE=on

--- a/integration/matchfunction/Dockerfile
+++ b/integration/matchfunction/Dockerfile
@@ -2,7 +2,7 @@
 ## SPDX-License-Identifier: MIT-0
 
 
-FROM public.ecr.aws/docker/library/golang:1.21.4-alpine3.18 AS builder
+FROM public.ecr.aws/docker/library/golang:1.24-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /app
 

--- a/integration/ncat-server/Dockerfile
+++ b/integration/ncat-server/Dockerfile
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 
-FROM public.ecr.aws/docker/library/golang:1.21.4-alpine3.18 AS go
+FROM public.ecr.aws/docker/library/golang:1.24-alpine AS go
 RUN apk add git
 WORKDIR /app
 ENV GO111MODULE=on


### PR DESCRIPTION
Fixes #54

## Summary

Update the Go builder image from `golang:1.21.4-alpine3.18` to `golang:1.24-alpine` in all three Dockerfiles. The `matchfunction` and `ncat-server` go.mod files specify `toolchain go1.24.1`, which requires Go 1.24+. Builds with the 1.21 image fail.

## Files Changed

- `integration/director/Dockerfile`
- `integration/matchfunction/Dockerfile`
- `integration/ncat-server/Dockerfile`

## Test plan

- [ ] `docker buildx build integration/director/`
- [ ] `docker buildx build integration/matchfunction/`
- [ ] `docker buildx build integration/ncat-server/`