### PR TITLE
Fix EKS cluster version: pass to child modules, align to 1.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ CIDR1="10.1.0.0/16"
 CLUSTER2=agones-gameservers-2
 REGION2=us-east-2
 CIDR2="10.2.0.0/16"
-VERSION="1.28"
+VERSION="1.32"
 ```
 
 For simplicity, we will be using local Terraform state files. In production workloads, we recommend storing the state files remotely, for example using the [S3 Terraform backend](https://developer.hashicorp.com/terraform/language/settings/backends/s3).

--- a/terraform/cloudformation/buildspec.yml
+++ b/terraform/cloudformation/buildspec.yml
@@ -31,7 +31,7 @@ phases:
       - go version
 
       - echo "Installing kubectl..."
-      - curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.28.0/2023-04-19/bin/linux/amd64/kubectl
+      - curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.32.0/2024-12-20/bin/linux/amd64/kubectl
       - chmod +x ./kubectl
       - mkdir -p $HOME/bin && cp ./kubectl $HOME/bin/kubectl && export PATH=$PATH:$HOME/bin
       - echo 'export PATH=$PATH:$HOME/bin' >> ~/.bashrc

--- a/terraform/cloudformation/main.yaml
+++ b/terraform/cloudformation/main.yaml
@@ -92,7 +92,7 @@ Parameters:
     Description: "CIDR block for the second EKS cluster VPC"
   KubernetesVersion:
     Type: String
-    Default: "1.28"
+    Default: "1.32"
     Description: "Kubernetes version for the EKS clusters"
   RepositoryOwner:
     Type: String

--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -4,6 +4,7 @@ module "cluster1" {
   source                                      = "./modules/cluster"
   cluster_name                                = var.cluster_1_name
   cluster_region                              = var.cluster_1_region
+  cluster_version                             = var.cluster_version
   cluster_cidr                                = var.cluster_1_cidr
   open_match                                  = true
   all_mngs_use_arm_based_instance_types       = var.all_arm_based_instances_cluster_1
@@ -17,6 +18,7 @@ module "cluster2" {
   source                                      = "./modules/cluster"
   cluster_name                                = var.cluster_2_name
   cluster_region                              = var.cluster_2_region
+  cluster_version                             = var.cluster_version
   cluster_cidr                                = var.cluster_2_cidr
   open_match                                  = false
   all_mngs_use_arm_based_instance_types       = var.all_arm_based_instances_cluster_2

--- a/terraform/cluster/modules/cluster/variables.tf
+++ b/terraform/cluster/modules/cluster/variables.tf
@@ -20,7 +20,7 @@ variable "cluster_cidr" {
 
 variable "cluster_version" {
   type    = string
-  default = "1.28"
+  default = "1.32"
 }
 
 # Variable for ensuring that all available Managed Node Groups (MNGs) use arm-based instances


### PR DESCRIPTION
Fixes #56

## Summary

- **Variable passthrough:** Add `cluster_version = var.cluster_version` to both module blocks in `terraform/cluster/main.tf`. Previously the variable was never passed, so child modules silently used their own default (1.28).
- **Align defaults:** Update child module default from "1.28" to "1.32" to match the root module.
- **CloudFormation:** Update `KubernetesVersion` parameter default to "1.32".
- **kubectl:** Update buildspec kubectl download from 1.28 to 1.32.
- **README:** Update VERSION example to "1.32".

## Files Changed

| File | Change |
|------|--------|
| `terraform/cluster/main.tf` | Pass `cluster_version` to both module blocks |
| `terraform/cluster/modules/cluster/variables.tf` | Default 1.28 to 1.32 |
| `terraform/cloudformation/main.yaml` | Default 1.28 to 1.32 |
| `terraform/cloudformation/buildspec.yml` | kubectl URL 1.28 to 1.32 |
| `README.md` | VERSION example 1.28 to 1.32 |

## Test plan

- [x] `terraform validate` passes
- [x] Full deploy with EKS 1.32 clusters