### PR TITLE
Override deleted Bitnami Redis image tags in Open Match

### DIFF
--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -237,6 +237,21 @@ resource "helm_release" "open-match" {
     value = "\\{\"openmatch\": \"system\"\\}"
   }
 
+  set {
+    name  = "redis.image.tag"
+    value = "latest"
+  }
+
+  set {
+    name  = "redis.metrics.image.tag"
+    value = "latest"
+  }
+
+  set {
+    name  = "redis.sysctl.image.tag"
+    value = "latest"
+  }
+
   depends_on = [
     module.eks_blueprints_addons,
     null_resource.generate_agones_certs,


### PR DESCRIPTION
Fixes #58

## Summary

Open Match bundles `bitnami/redis` chart 17.15.4 which pins three images that Bitnami has deleted from Docker Hub. Redis pods fail with `ErrImagePull`, blocking all Open Match functionality.

Override all three deleted image tags to `latest` via Helm set values:
- `redis.image.tag`
- `redis.metrics.image.tag`
- `redis.sysctl.image.tag`

This affects both OM 1.8.0 (current) and 1.8.1, since both bundle the same Redis chart version.

## Files Changed

| File | Change |
|------|--------|
| `terraform/intra-cluster/main.tf` | Add 3 `set` blocks to `helm_release "open-match"` |

## Test plan

- [x] `terraform validate` passes
- [ ] Open Match Redis pods start successfully after deploy