### PR TITLE
fix: disable Agones cleanupOnDelete to prevent teardown hang from pruned Bitnami image

### DIFF
--- a/terraform/intra-cluster/helm_values/agones-helm-values.yaml
+++ b/terraform/intra-cluster/helm_values/agones-helm-values.yaml
@@ -20,7 +20,7 @@ agones:
   registerApiService: true
   crds:
     install: true
-    cleanupOnDelete: true
+    cleanupOnDelete: false
   serviceaccount:
     allocator:
       name: agones-allocator


### PR DESCRIPTION
## Summary

- Disables `cleanupOnDelete` in Agones Helm values to prevent a 30-minute teardown hang caused by Bitnami's pruned `kubectl:1.30.4` image
- Fixes cascading failures: orphaned GameServer finalizers, stuck namespaces, orphaned ELBs/security groups, and AWS session expiry during destroy

Closes #61

## Details

The Agones 1.47.0 chart has a pre-delete hook Job that uses a hardcoded `bitnami/kubectl:1.30.4` image. Bitnami prunes old image tags from Docker Hub, so the image pull fails and `helm uninstall` hangs for 30 minutes before timing out.

Setting `cleanupOnDelete: false` skips this hook entirely. The pre-delete cleanup is unnecessary because Terraform destroys the entire EKS cluster afterward. With this setting, the Agones controller stays running during helm uninstall, processes GameServer finalizers normally, and Kubernetes Services are deleted cleanly (triggering proper ELB cleanup).

## Test plan

- [ ] `terraform validate` passes in `terraform/intra-cluster/`
- [ ] `terraform plan` shows the updated Agones Helm values
- [ ] Full deploy + destroy cycle completes without the 30-minute hang