### PR TITLE
fix: make namespace finalizer synchronous with retry logic and clear all finalizers

### DIFF
--- a/scripts/namespace-finalizer.sh
+++ b/scripts/namespace-finalizer.sh
@@ -1,6 +1,38 @@
+#!/usr/bin/env bash
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
-sleep 3
-NAMESPACE=$1
-kubectl get namespace ${NAMESPACE} && kubectl get namespace ${NAMESPACE} -o json | jq 'del(.spec.finalizers[0])' | kubectl replace --raw "/api/v1/namespaces/${NAMESPACE}/finalize" -f -
+set -euo pipefail
 
+NAMESPACE="${1:?Usage: namespace-finalizer.sh <namespace>}"
+MAX_RETRIES=5
+RETRY_DELAY=5
+
+for i in $(seq 1 "$MAX_RETRIES"); do
+  # Check if namespace still exists
+  if ! kubectl get namespace "$NAMESPACE" > /dev/null 2>&1; then
+    echo "Namespace $NAMESPACE does not exist or is already deleted."
+    exit 0
+  fi
+
+  # Check if namespace is stuck in Terminating
+  PHASE=$(kubectl get namespace "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+  if [ "$PHASE" != "Terminating" ]; then
+    echo "Namespace $NAMESPACE is in phase '$PHASE', not Terminating. Skipping finalizer removal."
+    exit 0
+  fi
+
+  # Remove all finalizers from the namespace
+  echo "Attempt $i/$MAX_RETRIES: Clearing finalizers on namespace $NAMESPACE..."
+  if kubectl get namespace "$NAMESPACE" -o json \
+    | jq '.spec.finalizers = []' \
+    | kubectl replace --raw "/api/v1/namespaces/${NAMESPACE}/finalize" -f - > /dev/null 2>&1; then
+    echo "Successfully cleared finalizers on namespace $NAMESPACE."
+    exit 0
+  fi
+
+  echo "Attempt $i failed. Retrying in ${RETRY_DELAY}s..."
+  sleep "$RETRY_DELAY"
+done
+
+echo "WARNING: Failed to clear finalizers on namespace $NAMESPACE after $MAX_RETRIES attempts."
+exit 1

--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -50,10 +50,8 @@ resource "kubernetes_namespace" "this" {
     name = each.key
   }
   provisioner "local-exec" {
-
     when    = destroy
-    command = "nohup ${path.module}/../../scripts/namespace-finalizer.sh ${each.key} 2>&1 &"
-    # command = "nohup ${path.module}/../../scripts/namespace-finalizer.sh ${var.cluster_name} ${each.key} 2>&1 &"
+    command = "${path.module}/../../scripts/namespace-finalizer.sh ${each.key}"
   }
 }
 


### PR DESCRIPTION
## Summary

- Makes the namespace finalizer script run synchronously so Terraform waits for it to complete
- Rewrites the script to clear all finalizers (not just the first one) with retry logic
- Removes fragile `nohup &` background execution and `sleep 3` timing hack

Closes #62

## Changes

**terraform/intra-cluster/main.tf:**
- Removed `nohup` and `&` from the destroy provisioner so Terraform waits for the script
- Removed dead commented-out code

**scripts/namespace-finalizer.sh:**
- Added `set -euo pipefail` for proper error handling
- Uses `.spec.finalizers = []` to clear ALL finalizers (previously only removed the first)
- Added retry loop (5 attempts, 5s apart) instead of a single `sleep 3`
- Checks namespace phase before attempting finalizer removal
- Exits cleanly if namespace is already gone

## Test plan

- [ ] `terraform validate` passes in `terraform/intra-cluster/`
- [ ] Script handles namespace that is already deleted (exits 0)
- [ ] Script handles namespace not in Terminating state (exits 0)
- [ ] Script clears multiple finalizers on a Terminating namespace
- [ ] Terraform destroy waits for script completion before proceeding