### PR TITLE
fix: add default value for aws_lb_arn to unblock extra-cluster destroy

### DIFF
--- a/terraform/extra-cluster/variables.tf
+++ b/terraform/extra-cluster/variables.tf
@@ -82,5 +82,6 @@ variable "cluster_2_gameservers_subnets" {
 }
 
 variable "aws_lb_arn" {
-  type = string
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
## Summary

- Adds `default = ""` to the `aws_lb_arn` variable so `terraform destroy` does not require a value that may no longer exist

Closes #63

## Details

The `aws_lb_arn` variable references a load balancer created by Kubernetes (via the AWS Load Balancer Controller for the Open Match Frontend ingress), not by Terraform. During `terraform destroy`, the LB may already be gone if the intra-cluster stage was destroyed first, making it difficult or impossible to provide the correct ARN.

Adding a default empty string allows destroy to proceed without requiring this value. The variable is only used in `aws_globalaccelerator_endpoint_group.aga_frontend`, which gets destroyed regardless of the provided value.

## Test plan

- [ ] `terraform validate` passes in `terraform/extra-cluster/`
- [ ] `terraform destroy` on extra-cluster succeeds without passing `aws_lb_arn`