### PR TITLE
fix: resolve kubectl context ambiguity when multiple contexts match cluster name

### DIFF
--- a/scripts/configure-agones-tls.sh
+++ b/scripts/configure-agones-tls.sh
@@ -4,7 +4,7 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 echo "- Verify that the Agones pods are running -"
 kubectl get pods -n agones-system -o wide
 export EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')

--- a/scripts/configure-agones-tls.sh
+++ b/scripts/configure-agones-tls.sh
@@ -4,7 +4,13 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+if [ -z "$CONTEXT" ]; then
+  echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME}'." >&2
+  kubectl config get-contexts -o=name >&2
+  exit 1
+fi
+kubectl config use-context "$CONTEXT"
 echo "- Verify that the Agones pods are running -"
 kubectl get pods -n agones-system -o wide
 export EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')

--- a/scripts/configure-multicluster-allocation.sh
+++ b/scripts/configure-multicluster-allocation.sh
@@ -4,9 +4,9 @@ set -o xtrace
 export CLUSTER1=$1
 export CLUSTER2=$2
 export ROOT_PATH=$3
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER2}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER2}$" | head -1)
 export ALLOCATOR_IP_CLUSTER2=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$" | head -1)
 export ALLOCATOR_IP_CLUSTER1=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 kubectl apply -f ${ROOT_PATH}/manifests/multicluster-allocation-1.yaml
 envsubst < ${ROOT_PATH}/manifests/multicluster-allocation-1-to-2.yaml | kubectl apply -f -

--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -4,7 +4,13 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+if [ -z "$CONTEXT" ]; then
+  echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME}'." >&2
+  kubectl config get-contexts -o=name >&2
+  exit 1
+fi
+kubectl config use-context "$CONTEXT"
 kubectl get pods -n open-match -o wide
 # Create Load Balancer
 kubectl expose deployment open-match-frontend  -n open-match  --type=LoadBalancer  --name="${CLUSTER_NAME}-om-fe"  --port=50504  --target-port=50504

--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -4,7 +4,7 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 kubectl get pods -n open-match -o wide
 # Create Load Balancer
 kubectl expose deployment open-match-frontend  -n open-match  --type=LoadBalancer  --name="${CLUSTER_NAME}-om-fe"  --port=50504  --target-port=50504

--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -8,7 +8,7 @@ export REGION2=$3
 export ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
 export REGISTRY=${ACCOUNT_ID}.dkr.ecr.${REGION1}.amazonaws.com
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 echo "- Create configmap -"
 # Create the configmap that will store the certs/keys used by the Open Match Director to access the 
 # Agones Allocator Service (we use the files `client_*` and `ca_*` 

--- a/scripts/deploy-mapping-configmap.sh
+++ b/scripts/deploy-mapping-configmap.sh
@@ -11,7 +11,13 @@ ACCELERATOR_2_DNS=$(aws globalaccelerator describe-custom-routing-accelerator --
 
 aws globalaccelerator list-custom-routing-port-mappings --region us-west-2  --accelerator-arn $ACCELERATOR_1  --query 'PortMappings[].[AcceleratorPort,DestinationSocketAddress.IpAddress,DestinationSocketAddress.Port]' | jq -c '.[] | {key: "\(.[1]):\(.[2] | tostring)", value: .[0]}' | jq -s 'from_entries' | gzip > mapping1.gz
 aws globalaccelerator list-custom-routing-port-mappings --region us-west-2  --accelerator-arn $ACCELERATOR_2  --query 'PortMappings[].[AcceleratorPort,DestinationSocketAddress.IpAddress,DestinationSocketAddress.Port]' | jq -c '.[] | {key: "\(.[1]):\(.[2] | tostring)", value: .[0]}' | jq -s 'from_entries' | gzip > mapping2.gz
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME_1}$" | head -1)
+CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME_1}$" | head -1)
+if [ -z "$CONTEXT" ]; then
+  echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME_1}'." >&2
+  kubectl config get-contexts -o=name >&2
+  exit 1
+fi
+kubectl config use-context "$CONTEXT"
 kubectl delete configmap global-accelerator-mapping --namespace agones-openmatch
 kubectl create configmap global-accelerator-mapping --namespace agones-openmatch --from-file=mapping1.gz --from-file=mapping2.gz --from-literal=accelerator1="$ACCELERATOR_1_DNS" --from-literal=accelerator2="$ACCELERATOR_2_DNS"
 rm mapping1.gz mapping2.gz

--- a/scripts/deploy-mapping-configmap.sh
+++ b/scripts/deploy-mapping-configmap.sh
@@ -11,7 +11,7 @@ ACCELERATOR_2_DNS=$(aws globalaccelerator describe-custom-routing-accelerator --
 
 aws globalaccelerator list-custom-routing-port-mappings --region us-west-2  --accelerator-arn $ACCELERATOR_1  --query 'PortMappings[].[AcceleratorPort,DestinationSocketAddress.IpAddress,DestinationSocketAddress.Port]' | jq -c '.[] | {key: "\(.[1]):\(.[2] | tostring)", value: .[0]}' | jq -s 'from_entries' | gzip > mapping1.gz
 aws globalaccelerator list-custom-routing-port-mappings --region us-west-2  --accelerator-arn $ACCELERATOR_2  --query 'PortMappings[].[AcceleratorPort,DestinationSocketAddress.IpAddress,DestinationSocketAddress.Port]' | jq -c '.[] | {key: "\(.[1]):\(.[2] | tostring)", value: .[0]}' | jq -s 'from_entries' | gzip > mapping2.gz
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME_1}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME_1}$" | head -1)
 kubectl delete configmap global-accelerator-mapping --namespace agones-openmatch
 kubectl create configmap global-accelerator-mapping --namespace agones-openmatch --from-file=mapping1.gz --from-file=mapping2.gz --from-literal=accelerator1="$ACCELERATOR_1_DNS" --from-literal=accelerator2="$ACCELERATOR_2_DNS"
 rm mapping1.gz mapping2.gz

--- a/scripts/deploy-matchfunction.sh
+++ b/scripts/deploy-matchfunction.sh
@@ -13,7 +13,7 @@ docker buildx build  --platform=linux/amd64 -t $REGISTRY/agones-openmatch-mmf in
 echo "- Push image to register -"
 docker push $REGISTRY/agones-openmatch-mmf
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$" | head -1)
 echo "- Deploy Open Match mmf to cluster ${CLUSTER_NAME1} -"
 envsubst < integration/matchfunction/matchfunction.yaml | kubectl apply --namespace ${NAMESPACE} -f -
 echo

--- a/scripts/deploy-ncat-fleets.sh
+++ b/scripts/deploy-ncat-fleets.sh
@@ -26,7 +26,7 @@ fi
 
 docker push $REGISTRY/agones-openmatch-ncat-server
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$" | head -1)
 export REGION=$REGION1
 echo "- Deploy fleets to cluster ${CLUSTER_NAME1} -"
 for f in manifests/fleets/${GAMESERVER_TYPE}/*
@@ -39,7 +39,7 @@ kubectl get fleets --namespace ${NAMESPACE}
 kubectl get gameservers --namespace ${NAMESPACE} --show-labels
 echo
 
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$" | head -1)
 export REGION=$REGION2
 echo "- Deploy fleets to cluster ${CLUSTER_NAME2} -"
 for f in manifests/fleets/${GAMESERVER_TYPE}/*

--- a/scripts/deploy-stk-fleets.sh
+++ b/scripts/deploy-stk-fleets.sh
@@ -36,7 +36,7 @@ docker push $REGISTRY/supertuxkart-server
 echo "supertuxkart build and push was successful"
 
 echo "- Deploy fleets to cluster ${CLUSTER_NAME1} -"
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$" | head -1)
 export REGION=$REGION1
 for f in manifests/fleets/${GAMESERVER_TYPE}/*
 do
@@ -50,7 +50,7 @@ echo
 
 
 echo "- Deploy fleets to cluster ${CLUSTER_NAME2} -"
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$" | head -1)
 export REGION=$REGION2
 for f in manifests/fleets/${GAMESERVER_TYPE}/*
 do

--- a/scripts/generate-agones-certs.sh
+++ b/scripts/generate-agones-certs.sh
@@ -4,7 +4,7 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 echo "- Verify that the cert-manager pods are running -"
 kubectl get pods -n cert-manager -o wide
 echo "- Verify the cert-manager webhook is available -"

--- a/scripts/generate-agones-certs.sh
+++ b/scripts/generate-agones-certs.sh
@@ -4,7 +4,13 @@ set -o xtrace
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+if [ -z "$CONTEXT" ]; then
+  echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME}'." >&2
+  kubectl config get-contexts -o=name >&2
+  exit 1
+fi
+kubectl config use-context "$CONTEXT"
 echo "- Verify that the cert-manager pods are running -"
 kubectl get pods -n cert-manager -o wide
 echo "- Verify the cert-manager webhook is available -"

--- a/scripts/generate-tls-files.sh
+++ b/scripts/generate-tls-files.sh
@@ -3,7 +3,7 @@
 set -o xtrace
 export CLUSTER_NAME=$1
 export ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 KEY_FILE=${ROOT_PATH}/client_${CLUSTER_NAME}.key
 CERT_FILE=${ROOT_PATH}/client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=${ROOT_PATH}/ca_${CLUSTER_NAME}.crt

--- a/scripts/generate-tls-files.sh
+++ b/scripts/generate-tls-files.sh
@@ -3,7 +3,13 @@
 set -o xtrace
 export CLUSTER_NAME=$1
 export ROOT_PATH=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+if [ -z "$CONTEXT" ]; then
+  echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME}'." >&2
+  kubectl config get-contexts -o=name >&2
+  exit 1
+fi
+kubectl config use-context "$CONTEXT"
 KEY_FILE=${ROOT_PATH}/client_${CLUSTER_NAME}.key
 CERT_FILE=${ROOT_PATH}/client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=${ROOT_PATH}/ca_${CLUSTER_NAME}.crt

--- a/scripts/set-allocator-ip.sh
+++ b/scripts/set-allocator-ip.sh
@@ -1,6 +1,11 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 CLUSTER_NAME=$1
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1) 2>&1 > /dev/null
+CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
+if [ -z "$CONTEXT" ]; then
+  echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME}'." >&2
+  exit 1
+fi
+kubectl config use-context "$CONTEXT" > /dev/null 2>&1
 ALLOCATOR_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 echo ${ALLOCATOR_IP}

--- a/scripts/set-allocator-ip.sh
+++ b/scripts/set-allocator-ip.sh
@@ -1,6 +1,6 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 CLUSTER_NAME=$1
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$") 2>&1 > /dev/null
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1) 2>&1 > /dev/null
 ALLOCATOR_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 echo ${ALLOCATOR_IP}

--- a/scripts/test-agones-tls.sh
+++ b/scripts/test-agones-tls.sh
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 export CLUSTER_NAME=$1
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 KEY_FILE=client_${CLUSTER_NAME}.key
 CERT_FILE=client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=ca_${CLUSTER_NAME}.crt

--- a/scripts/test-gameserver-allocation.sh
+++ b/scripts/test-gameserver-allocation.sh
@@ -5,7 +5,7 @@ echo "#####"
 NAMESPACE=gameservers
 CLUSTER_NAME=$1
 REGION=$2
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 KEY_FILE=client_${CLUSTER_NAME}.key
 CERT_FILE=client_${CLUSTER_NAME}.crt
 TLS_CA_FILE=ca_${CLUSTER_NAME}.crt

--- a/scripts/test-gameserver-multicluster-allocation.sh
+++ b/scripts/test-gameserver-multicluster-allocation.sh
@@ -11,7 +11,7 @@ REGION2=$4
 KEY_FILE=client_${CLUSTER_NAME1}.key
 CERT_FILE=client_${CLUSTER_NAME1}.crt
 TLS_CA_FILE=ca_${CLUSTER_NAME1}.crt
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME1}$" | head -1)
 EXTERNAL_IP=$(kubectl get services agones-allocator -n agones-system -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 ENDPOINT=https://${EXTERNAL_IP}/gameserverallocation
 echo "- Allocating server -"
@@ -19,6 +19,6 @@ curl ${ENDPOINT} --key ${KEY_FILE} --cert ${CERT_FILE} --cacert ${TLS_CA_FILE} -
 echo
 echo "- Display ALLOCATED game servers on cluster ${CLUSTER_NAME1} only -"
 kubectl get gameservers --namespace ${GAMESERVER_NAMESPACE} | grep Allocated
-kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$")
+kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME2}$" | head -1)
 echo "- Display ALLOCATED game servers on cluster ${CLUSTER_NAME2} only -"
 kubectl get gameservers --namespace ${GAMESERVER_NAMESPACE} | grep Allocated

--- a/terraform/cloudformation/buildspec.yml
+++ b/terraform/cloudformation/buildspec.yml
@@ -194,7 +194,7 @@ phases:
       - echo "Integrating Open Match with Agones..."
       - |
         cd $CODEBUILD_SRC_DIR
-        kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$")
+        kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$" | head -1)
         sh scripts/deploy-matchfunction.sh ${CLUSTER1} ${REGION1}
         sh scripts/deploy-director.sh ${CLUSTER1} ${REGION1} ${REGION2}
         kubectl get pods -n agones-openmatch

--- a/terraform/cloudformation/cleanup-buildspec.yml
+++ b/terraform/cloudformation/cleanup-buildspec.yml
@@ -245,8 +245,8 @@ phases:
       # Remove the clusters from kubectl config
       - |
         echo "Removing clusters from kubectl config..."
-        kubectl config delete-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER1}$") 2>/dev/null || echo "No kubectl context found for cluster 1"
-        kubectl config delete-context $(kubectl config get-contexts -o=name | grep "/${CLUSTER2}$") 2>/dev/null || echo "No kubectl context found for cluster 2"
+        kubectl config get-contexts -o=name | grep "/${CLUSTER1}$" | xargs -I{} kubectl config delete-context {} 2>/dev/null || echo "No kubectl context found for cluster 1"
+        kubectl config get-contexts -o=name | grep "/${CLUSTER2}$" | xargs -I{} kubectl config delete-context {} 2>/dev/null || echo "No kubectl context found for cluster 2"
 
   post_build:
     commands:

--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -332,7 +332,7 @@ resource "null_resource" "open_match_tls_hardening" {
   provisioner "local-exec" {
     when    = create
     command = <<-EOT
-      kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${var.cluster_name}$") && \
+      kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${var.cluster_name}$" | head -1) && \
       kubectl set env deployment/open-match-frontend -n open-match GODEBUG=tls3des=0 && \
       kubectl set env deployment/open-match-backend -n open-match GODEBUG=tls3des=0 && \
       kubectl set env deployment/open-match-query -n open-match GODEBUG=tls3des=0

--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -332,7 +332,12 @@ resource "null_resource" "open_match_tls_hardening" {
   provisioner "local-exec" {
     when    = create
     command = <<-EOT
-      kubectl config use-context $(kubectl config get-contexts -o=name | grep "/${var.cluster_name}$" | head -1) && \
+      CONTEXT=$(kubectl config get-contexts -o=name | grep "/${var.cluster_name}$" | head -1)
+      if [ -z "$CONTEXT" ]; then
+        echo "ERROR: No kubectl context found for cluster '${var.cluster_name}'. Run: aws eks update-kubeconfig --name ${var.cluster_name}" >&2
+        exit 1
+      fi
+      kubectl config use-context "$CONTEXT" && \
       kubectl set env deployment/open-match-frontend -n open-match GODEBUG=tls3des=0 && \
       kubectl set env deployment/open-match-backend -n open-match GODEBUG=tls3des=0 && \
       kubectl set env deployment/open-match-query -n open-match GODEBUG=tls3des=0


### PR DESCRIPTION
## Summary

- Adds `| head -1` to all kubectl context-switching grep patterns across 14 scripts, 1 Terraform file, and 1 buildspec to prevent silent failures when multiple contexts match the same cluster name
- Adds early-exit validation guards to critical scripts (those invoked during Terraform apply) that fail fast with an actionable error when no context is found
- Fixes `cleanup-buildspec.yml` to use `xargs` so all matching stale contexts are deleted during cleanup
- Fixes incorrect redirect order in `set-allocator-ip.sh` (`2>&1 > /dev/null` → `> /dev/null 2>&1`)

## Problem

When users deploy to different regions or have stale kubeconfig contexts from a previous deployment, `grep "/${CLUSTER_NAME}$"` returns multiple matches. This causes `kubectl config use-context` to fail silently, and without `set -e` the script continues executing against whatever cluster was previously active — potentially deploying, deleting, or configuring on the wrong cluster.

This was discovered during a live deploy where the `agones_tls_configuration` Terraform resource looped for 2.5+ hours waiting for a secret on the wrong cluster.

## Test plan

- [x] Added stale us-west-2 context alongside active us-east-1 context
- [x] Verified `configure-agones-tls.sh` picks the correct context and completes TLS configuration
- [x] Verified `set-allocator-ip.sh` returns the correct cluster's allocator IP
- [x] Verified `generate-tls-files.sh` switches to the correct context
- [x] Verified nonexistent cluster name exits immediately with actionable error message
- [x] Verified all scripts without validation still get `| head -1` for determinism

Closes #69