### PR TITLE
fix: authenticate to public ECR before docker builds

### DIFF
--- a/scripts/deploy-director.sh
+++ b/scripts/deploy-director.sh
@@ -21,6 +21,7 @@ kubectl create configmap allocator-tls -n agones-openmatch \
 
 echo "- Login to ECR registry -"
 aws ecr get-login-password --region ${REGION1} | docker login --username AWS --password-stdin $REGISTRY
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 echo "- Build director image -"
 docker buildx build  --platform=linux/amd64 -t $REGISTRY/agones-openmatch-director integration/director
 echo "- Push image to register -"

--- a/scripts/deploy-matchfunction.sh
+++ b/scripts/deploy-matchfunction.sh
@@ -8,6 +8,7 @@ export REGISTRY=${ACCOUNT_ID}.dkr.ecr.${REGION1}.amazonaws.com
 
 echo "- Login to ECR registry -"
 aws ecr get-login-password --region ${REGION1} | docker login --username AWS --password-stdin $REGISTRY
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 echo "- Build matchfunction image -"
 docker buildx build  --platform=linux/amd64 -t $REGISTRY/agones-openmatch-mmf integration/matchfunction
 echo "- Push image to register -"

--- a/scripts/deploy-ncat-fleets.sh
+++ b/scripts/deploy-ncat-fleets.sh
@@ -12,6 +12,7 @@ export ARCHITECTURE=$5
 
 
 aws ecr get-login-password --region ${REGION1} | docker login --username AWS --password-stdin $REGISTRY
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 #docker buildx build --platform=linux/amd64  -t $REGISTRY/agones-openmatch-ncat-server integration/ncat-server
 #docker buildx build --platform=linux/arm64  -t $REGISTRY/agones-openmatch-ncat-server integration/ncat-server
 echo "Architecture is" $ARCHITECTURE

--- a/scripts/deploy-stk-fleets.sh
+++ b/scripts/deploy-stk-fleets.sh
@@ -21,6 +21,7 @@ curl -L -o integration/clients/stk-server-build/main.go https://raw.githubuserco
 
 echo "- Creating tailored supertuxkart image (amd64 or arm64) -"
 aws ecr get-login-password --region ${REGION1} | docker login --username AWS --password-stdin $REGISTRY
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
 if [[ $ARCHITECTURE == "arm64" ]];
 then 


### PR DESCRIPTION
## Summary

- Adds `aws ecr-public get-login-password` authentication to deploy scripts before `docker buildx build`
- Prevents 403 failures caused by stale ECR public tokens in Docker's credential store
- Raises pull rate limit from 1/sec (unauthenticated) to 10/sec (authenticated)

## Test plan

- [x] Reproduced 403 by building with expired public ECR token
- [x] Verified fix resolves the issue (fresh token used, build succeeds)
- [x] Verified builds still work for users who have never authenticated to public ECR

Closes #71