### PR TITLE
fix: use Go default GOPROXY setting in all Dockerfiles

### DIFF
--- a/integration/director/Dockerfile
+++ b/integration/director/Dockerfile
@@ -5,7 +5,7 @@ FROM public.ecr.aws/docker/library/golang:1.24-alpine as go
 RUN apk add git
 WORKDIR /app
 ENV GO111MODULE=on
-ENV GOPROXY=direct,https://proxy.golang.org
+ENV GOPROXY=https://proxy.golang.org,direct
 
 COPY go.mod .
 COPY go.sum .

--- a/integration/matchfunction/Dockerfile
+++ b/integration/matchfunction/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache git
 WORKDIR /app
 
 # Set Go Proxy env variables
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 # Leverage caching by copying go.mod and go.sum first
 COPY go.mod go.sum ./
 RUN go mod download

--- a/integration/ncat-server/Dockerfile
+++ b/integration/ncat-server/Dockerfile
@@ -5,7 +5,7 @@ FROM public.ecr.aws/docker/library/golang:1.24-alpine AS go
 RUN apk add git
 WORKDIR /app
 ENV GO111MODULE=on
-ENV GOPROXY=direct,https://proxy.golang.org
+ENV GOPROXY=https://proxy.golang.org,direct
 
 COPY go.mod .
 COPY go.sum .


### PR DESCRIPTION
## Summary

- Standardizes all Dockerfiles to `GOPROXY=https://proxy.golang.org,direct` (Go default)
- Replaces `direct,https://proxy.golang.org` which bypasses the proxy and fetches directly from VCS hosts (github.com, agones.dev, googleapis, etc.)
- Removes third-party `goproxy.io` dependency from the matchfunction Dockerfile

## Why

Go processes the GOPROXY list left-to-right and only falls back to the next entry on 404/410 errors. With `direct` first, Go fetches via `git clone` from each module's VCS host. Since VCS access almost never returns 404 (it either succeeds or fails with a non-404 error), the proxy fallback is effectively dead code — Go always hits VCS directly.

This matters because:
- `direct` requires network access to 6+ VCS hosts (github.com, agones.dev, google.golang.org, etc.)
- Corporate firewalls that block/inspect outbound HTTPS to arbitrary domains break the build
- With `proxy.golang.org` first, Go only needs access to **one well-known endpoint** and benefits from its module cache
- Fallback to `direct` still works for any module not on the proxy (rare for public modules)

Additionally, the matchfunction Dockerfile used `goproxy.io`, a third-party community proxy (primarily targeting users in China where Google is blocked). This introduces an unnecessary supply-chain dependency when building in AWS regions where `proxy.golang.org` is fully accessible.

## Test plan

- [x] Verified all three images build successfully with the new GOPROXY setting
- [x] Confirmed `proxy.golang.org` serves all required modules (agones.dev, open-match.dev, etc.)

Closes #72