### PR TITLE
Fix Open Match Frontend exposing prohibited TLS cipher suites

### DIFF
--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -39,16 +39,17 @@ kubectl delete pods -n open-match --all
 kubectl get secret open-match-tls-certmanager -o json -n open-match | jq '.metadata.namespace="agones-openmatch" | del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp)' | kubectl apply -f -
 
 # Import the certificate into ACM for NLB TLS termination
-TMPDIR=$(mktemp -d)
-trap "rm -rf ${TMPDIR}" EXIT
-echo "${TLS_CERT_VALUE}" | base64 -d > "${TMPDIR}/tls.crt"
-echo "${TLS_KEY_VALUE}" | base64 -d > "${TMPDIR}/tls.key"
-echo "${TLS_CA_VALUE}" | base64 -d > "${TMPDIR}/ca.crt"
+CERT_TMPDIR=$(mktemp -d)
+chmod 700 "${CERT_TMPDIR}"
+trap "rm -rf ${CERT_TMPDIR}" EXIT
+echo "${TLS_CERT_VALUE}" | base64 -d > "${CERT_TMPDIR}/tls.crt"
+echo "${TLS_KEY_VALUE}" | base64 -d > "${CERT_TMPDIR}/tls.key"
+echo "${TLS_CA_VALUE}" | base64 -d > "${CERT_TMPDIR}/ca.crt"
 
 ACM_ARN=$(aws acm import-certificate \
-  --certificate "fileb://${TMPDIR}/tls.crt" \
-  --private-key "fileb://${TMPDIR}/tls.key" \
-  --certificate-chain "fileb://${TMPDIR}/ca.crt" \
+  --certificate "fileb://${CERT_TMPDIR}/tls.crt" \
+  --private-key "fileb://${CERT_TMPDIR}/tls.key" \
+  --certificate-chain "fileb://${CERT_TMPDIR}/ca.crt" \
   --region "${REGION}" \
   --tags Key=Name,Value="${CLUSTER_NAME}-open-match-frontend" \
   --output text --query CertificateArn)

--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -1,9 +1,11 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: MIT-0
 set -o xtrace
+set -e
 echo "#####"
 CLUSTER_NAME=$1
 ROOT_PATH=$2
+REGION=$3
 CONTEXT=$(kubectl config get-contexts -o=name | grep "/${CLUSTER_NAME}$" | head -1)
 if [ -z "$CONTEXT" ]; then
   echo "ERROR: No kubectl context found matching cluster '${CLUSTER_NAME}'." >&2
@@ -12,19 +14,20 @@ if [ -z "$CONTEXT" ]; then
 fi
 kubectl config use-context "$CONTEXT"
 kubectl get pods -n open-match -o wide
-# Create Load Balancer
-kubectl expose deployment open-match-frontend  -n open-match  --type=LoadBalancer  --name="${CLUSTER_NAME}-om-fe"  --port=50504  --target-port=50504
-# Add annotations to create the LB as an internet facing NLB (to be accessed by the clients and used with Global Accelerator)
-kubectl annotate svc ${CLUSTER_NAME}-om-fe service.beta.kubernetes.io/aws-load-balancer-scheme=internet-facing --overwrite=true -n open-match
-kubectl annotate svc ${CLUSTER_NAME}-om-fe service.beta.kubernetes.io/aws-load-balancer-type=nlb --overwrite=true -n open-match
 
 # Create a certificate for open-match
 kubectl apply -f ${ROOT_PATH}/manifests/open-match-tls-certmanager.cert.yaml
 
-# Modify the secrets open-match-tls-rootca and open-match-tls-server installed by helm with the values from open-match-tls-certmanager
+# Wait for the certificate secret to be ready
+echo "Waiting for open-match-tls-certmanager secret..."
+kubectl wait --for=condition=Ready certificate/open-match-tls-certmanager -n open-match --timeout=120s
+
+# Extract certificate from Kubernetes secret
 TLS_CA_VALUE=$(kubectl get secret open-match-tls-certmanager -n open-match -ojsonpath='{.data.ca\.crt}')
 TLS_CERT_VALUE=$(kubectl get secret open-match-tls-certmanager -n open-match -ojsonpath='{.data.tls\.crt}')
 TLS_KEY_VALUE=$(kubectl get secret open-match-tls-certmanager -n open-match -ojsonpath='{.data.tls\.key}')
+
+# Modify the secrets open-match-tls-rootca and open-match-tls-server installed by helm with the values from open-match-tls-certmanager
 kubectl get secret open-match-tls-rootca -o json -n open-match | jq '.data["public.cert"]="'${TLS_CA_VALUE}'"' | kubectl apply -f -
 kubectl get secret open-match-tls-server -o json -n open-match | jq '.data["public.cert"]="'${TLS_CERT_VALUE}'"' | kubectl apply -f -
 kubectl get secret open-match-tls-server -o json -n open-match | jq '.data["private.key"]="'${TLS_KEY_VALUE}'"' | kubectl apply -f -
@@ -34,3 +37,33 @@ kubectl delete pods -n open-match --all
 
 # Copy the open-match-tls-certmanager from open-match to agones-openmatch namespace
 kubectl get secret open-match-tls-certmanager -o json -n open-match | jq '.metadata.namespace="agones-openmatch"' | kubectl apply -f -
+
+# Import the certificate into ACM for NLB TLS termination
+TMPDIR=$(mktemp -d)
+trap "rm -rf ${TMPDIR}" EXIT
+echo "${TLS_CERT_VALUE}" | base64 -d > "${TMPDIR}/tls.crt"
+echo "${TLS_KEY_VALUE}" | base64 -d > "${TMPDIR}/tls.key"
+echo "${TLS_CA_VALUE}" | base64 -d > "${TMPDIR}/ca.crt"
+
+ACM_ARN=$(aws acm import-certificate \
+  --certificate "fileb://${TMPDIR}/tls.crt" \
+  --private-key "fileb://${TMPDIR}/tls.key" \
+  --certificate-chain "fileb://${TMPDIR}/ca.crt" \
+  --region "${REGION}" \
+  --tags Key=Name,Value="${CLUSTER_NAME}-open-match-frontend" \
+  --output text --query CertificateArn)
+
+echo "Imported certificate to ACM: ${ACM_ARN}"
+
+# Create Load Balancer with TLS termination
+kubectl expose deployment open-match-frontend -n open-match --type=LoadBalancer --name="${CLUSTER_NAME}-om-fe" --port=50504 --target-port=50504 --dry-run=client -o yaml | kubectl apply -f -
+
+# Annotate the service for NLB with TLS termination (AWS Load Balancer Controller)
+kubectl annotate svc ${CLUSTER_NAME}-om-fe -n open-match --overwrite=true \
+  service.beta.kubernetes.io/aws-load-balancer-type=external \
+  service.beta.kubernetes.io/aws-load-balancer-nlb-target-type=ip \
+  service.beta.kubernetes.io/aws-load-balancer-scheme=internet-facing \
+  service.beta.kubernetes.io/aws-load-balancer-ssl-cert="${ACM_ARN}" \
+  service.beta.kubernetes.io/aws-load-balancer-ssl-ports="50504" \
+  service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy=ELBSecurityPolicy-TLS13-1-2-Res-2021-06 \
+  service.beta.kubernetes.io/aws-load-balancer-backend-protocol=ssl

--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -36,7 +36,7 @@ kubectl get secret open-match-tls-server -o json -n open-match | jq '.data["priv
 kubectl delete pods -n open-match --all
 
 # Copy the open-match-tls-certmanager from open-match to agones-openmatch namespace
-kubectl get secret open-match-tls-certmanager -o json -n open-match | jq '.metadata.namespace="agones-openmatch"' | kubectl apply -f -
+kubectl get secret open-match-tls-certmanager -o json -n open-match | jq '.metadata.namespace="agones-openmatch" | del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp)' | kubectl apply -f -
 
 # Import the certificate into ACM for NLB TLS termination
 TMPDIR=$(mktemp -d)

--- a/scripts/configure-open-match-ingress.sh
+++ b/scripts/configure-open-match-ingress.sh
@@ -56,15 +56,28 @@ ACM_ARN=$(aws acm import-certificate \
 
 echo "Imported certificate to ACM: ${ACM_ARN}"
 
-# Create Load Balancer with TLS termination
-kubectl expose deployment open-match-frontend -n open-match --type=LoadBalancer --name="${CLUSTER_NAME}-om-fe" --port=50504 --target-port=50504 --dry-run=client -o yaml | kubectl apply -f -
-
-# Annotate the service for NLB with TLS termination (AWS Load Balancer Controller)
-kubectl annotate svc ${CLUSTER_NAME}-om-fe -n open-match --overwrite=true \
-  service.beta.kubernetes.io/aws-load-balancer-type=external \
-  service.beta.kubernetes.io/aws-load-balancer-nlb-target-type=ip \
-  service.beta.kubernetes.io/aws-load-balancer-scheme=internet-facing \
-  service.beta.kubernetes.io/aws-load-balancer-ssl-cert="${ACM_ARN}" \
-  service.beta.kubernetes.io/aws-load-balancer-ssl-ports="50504" \
-  service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy=ELBSecurityPolicy-TLS13-1-2-Res-2021-06 \
-  service.beta.kubernetes.io/aws-load-balancer-backend-protocol=ssl
+# Create Load Balancer with TLS termination (annotations inline to prevent in-tree controller race)
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${CLUSTER_NAME}-om-fe
+  namespace: open-match
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: external
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "${ACM_ARN}"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "50504"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS13-1-2-Res-2021-06
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: ssl
+spec:
+  type: LoadBalancer
+  selector:
+    app: open-match
+    component: frontend
+  ports:
+    - port: 50504
+      targetPort: 50504
+      protocol: TCP
+EOF

--- a/terraform/cluster/modules/cluster/main.tf
+++ b/terraform/cluster/modules/cluster/main.tf
@@ -243,6 +243,10 @@ module "vpc" {
   default_security_group_tags   = { Name = "${var.cluster_name}-default" }
 
 
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
   private_subnet_tags = {
     "kubernetes.io/role/internal-elb" = 1
   }

--- a/terraform/intra-cluster/main.tf
+++ b/terraform/intra-cluster/main.tf
@@ -308,7 +308,7 @@ resource "null_resource" "open_match_ingress_configuration" {
 
   provisioner "local-exec" {
     when    = create
-    command = "nohup ${local.repo_root}/scripts/configure-open-match-ingress.sh ${var.cluster_name} ${local.repo_root} &"
+    command = "${local.repo_root}/scripts/configure-open-match-ingress.sh ${var.cluster_name} ${local.repo_root} ${var.cluster_region}"
   }
 
   depends_on = [


### PR DESCRIPTION
## Summary

- Enable NLB TLS termination for the Open Match Frontend gRPC endpoint (port 50504) using `ELBSecurityPolicy-TLS13-1-2-Res-2021-06`
- Import existing cert-manager certificate into ACM for NLB reference
- Switch from in-tree cloud provider (`type=nlb`) to AWS Load Balancer Controller (`type=external`) for TLS support
- Add `kubernetes.io/role/elb` tag to public subnets (required by AWS LB Controller for internet-facing NLBs)
- Fix secret copy conflict on re-runs by stripping stale metadata

## Test plan

- [x] Deployed to `agones-gameservers-1` cluster in us-east-1
- [x] NLB created with TLS listener on port 50504
- [x] Target group health: healthy
- [x] nmap `ssl-enum-ciphers` confirms only TLS 1.2 (ECDHE+GCM) and TLS 1.3 ciphers offered
- [x] Zero 3DES, CBC, TLS 1.0/1.1 ciphers exposed
- [ ] Verify security scanner clears findings on next rescan

Closes #75