### PR TITLE
chore: expand .gitignore for terraform artifacts and editor/tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,16 @@
 tempfile.json
 .DS_Store
 .idea
+.vscode/
+.claude/
+.kiro/
 .terraform*
 terraform.tfstate*
+*.tfplan
+crash.log
+override.tf
+override.tf.json
 go.work*
+*.tfvars
+*.tfvars.json
+!*.tfvars.example


### PR DESCRIPTION
## Summary

Expand `.gitignore` to cover artifacts and local config that should never be committed:

- **`*.tfvars` / `*.tfvars.json`** — user-specific deployment configuration (cluster names, regions, CIDRs). Follows the canonical [GitHub Terraform .gitignore](https://github.com/github/gitignore/blob/main/Terraform.gitignore) convention and HashiCorp's guidance to keep environment-specific tfvars out of VCS.
- **`!*.tfvars.example`** — negation so the tracked `agones.tfvars.example` template (added in #68) stays committed. Users copy it to `agones.tfvars` and fill in their values.
- **`*.tfplan`, `crash.log`, `override.tf`, `override.tf.json`** — standard Terraform artifacts from the canonical template.
- **`.vscode/`, `.claude/`, `.kiro/`** — editor/tooling directories.

## Why

These files are either environment-specific, transient build artifacts, or local tooling config — none belong in version control. The tfvars rules in particular prevent accidental commit of per-deployment configuration.